### PR TITLE
enable creating rfc2047-compatible emails

### DIFF
--- a/email_address/src/dune
+++ b/email_address/src/dune
@@ -1,2 +1,2 @@
 (library (name email_address) (public_name email_message.email_address)
- (libraries angstrom core) (preprocess (pps ppx_jane)))
+ (libraries angstrom core base64) (preprocess (pps ppx_jane)))

--- a/email_address/src/email_address.ml
+++ b/email_address/src/email_address.ml
@@ -69,6 +69,15 @@ module Stable = struct
         | Some prefix -> Core.sprintf "%s<%s>" prefix address_part
       ;;
 
+      let compose_utf8 ~prefix ~address_part =
+        match prefix with
+        | None -> address_part
+        | Some prefix ->
+          let encoded_prefix= Base64.encode_string prefix in
+          let prefix_utf8= Core.sprintf "=?%s?B?%s?=" "UTF-8" encoded_prefix in
+          Core.sprintf "%s<%s>" prefix_utf8 address_part
+      ;;
+
       let to_string t =
         let address_part =
           match t.domain with
@@ -76,6 +85,15 @@ module Stable = struct
           | Some domain -> Core.sprintf "%s@%s" t.local_part domain
         in
         compose ~prefix:t.prefix ~address_part
+      ;;
+
+      let to_string_utf8 t =
+        let address_part =
+          match t.domain with
+          | None -> t.local_part
+          | Some domain -> Core.sprintf "%s@%s" t.local_part domain
+        in
+        compose_utf8 ~prefix:t.prefix ~address_part
       ;;
 
       include Sexpable.Of_stringable.V1 (struct

--- a/email_address/src/email_address.mli
+++ b/email_address/src/email_address.mli
@@ -23,6 +23,7 @@ val of_string_exn : ?default_domain:string -> string -> t
 val list_of_string : ?default_domain:string -> string -> t list Or_error.t
 val list_of_string_exn : ?default_domain:string -> string -> t list
 val to_string : t -> string
+val to_string_utf8 : t -> string
 val list_to_header_value : t list -> string
 val local_part : t -> string
 val set_local_part : t -> string -> t

--- a/src/email_simple.ml
+++ b/src/email_simple.ml
@@ -311,6 +311,41 @@ let create
     content
 ;;
 
+let create_utf8
+      ?from
+      ~to_
+      ?cc
+      ?reply_to
+      ~subject
+      ?id
+      ?in_reply_to
+      ?date
+      ?auto_generated
+      ?extra_headers
+      ?attachments
+      ?no_tracing_headers
+      content
+  =
+  let subject_utf8=
+    let encoded_subject= Base64.encode_string subject in
+    Core.sprintf "=?%s?B?%s?=" "UTF-8" encoded_subject
+  in
+  Expert.create_raw
+    ?from:(Option.map from ~f:Email_address.to_string_utf8)
+    ~to_:(List.map to_ ~f:Email_address.to_string_utf8)
+    ?cc:(Option.map cc ~f:(List.map ~f:Email_address.to_string_utf8))
+    ?reply_to:(Option.map reply_to ~f:Email_address.to_string_utf8)
+    ~subject:subject_utf8
+    ?id
+    ?in_reply_to
+    ?date:(Option.map date ~f:Email_date.rfc822_date)
+    ?auto_generated
+    ?extra_headers
+    ?attachments
+    ?no_tracing_headers
+    content
+;;
+
 let parse_attachment ~include_inline_parts ?container_headers ~path t =
   let headers = Email.headers t in
   let as_attachment ~even_if_multipart ~filename =

--- a/src/email_simple.mli
+++ b/src/email_simple.mli
@@ -77,6 +77,22 @@ val create
   -> Content.t
   -> t
 
+val create_utf8
+  :  ?from:Email_address.t (** defaults to <user@host> *)
+  -> to_:Email_address.t list
+  -> ?cc:Email_address.t list
+  -> ?reply_to:Email_address.t
+  -> subject:string
+  -> ?id:string
+  -> ?in_reply_to:string
+  -> ?date:Time_float.t
+  -> ?auto_generated:unit
+  -> ?extra_headers:(Headers.Name.t * Headers.Value.t) list
+  -> ?attachments:(attachment_name * Content.t) list
+  -> ?no_tracing_headers:[ `Because_not_using_standard_email_infra ]
+  -> Content.t
+  -> t
+
 (** A unique value to be used in a Message-Id header *)
 val make_id : unit -> Headers.Value.t
 


### PR DESCRIPTION
This PR is both an issue report and eh, a PR.

This PR only adds a small functionality to send rfc 2047 compliant utf8 emails. It's used more or less for my personal usecase. The text below is an issue report.

Currently, this library lacks the ability to deal with rfc 2047 compliant emails.

Although it already has a module named `encoded_word`, it just strips rfc 2047 wrap and returns the base64/quoted_printable decoded data directly without charset information.

``` ocaml
val Encoded_word.decode : string -> string Or_error.t
```

That is, if someone sends me an email with the `from`, `to`, `subject` header fileds encoded with gb2312 encoding, after being processed by this library, raw gb2312 of those fields are returned without charset information. That can be improved in future releases.

I've used this library for several years. As I need to send emails to Asian users, so I always maintain a private version of this library so that my Chinese, Japanese users will receive emails explicitly indicating that the header fields in those emails are encoded in utf8 so they won't see messy code in those emails.

According to rfc 2047, each field can specify its charset encoding. IMHO, the API of the library need a new version so that charset encoding information of each field will be explicit and then it can be used in international environment.